### PR TITLE
Se añade jitter.base a simdata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SSP
 Title: Simulated Sampling Procedure for Community Ecology
-Version: 1.0.2
+Version: 1.1.0
 Date: 2025-04-23
 Authors@R: c(person(given = "Edlin", family = "Guerra-Castro", role = c("aut", "cre"), email = "edlinguerra@gmail.com"),
     person(given = "Maite", family = "Mascaro", role = "aut", email = "mmm@ciencias.unam.mx"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# SSP 1.1.0
+
+## Function adjustments
+
+- `simdata()` can now introduce mild randomness via the new `jitter.base` 
+  parameter to increase variability among simulated communities. This feature is 
+  optional (default `jitter.base = 0`).
+
 
 # SSP 1.0.2 (2025-04-23)
 

--- a/R/simdata.R
+++ b/R/simdata.R
@@ -7,6 +7,7 @@
 #' @param cases Number of data sets to simulate.
 #' @param N Number of samples to simulate in each site.
 #' @param sites Number of sites to simulate in each data set.
+#' @param jitter.base Numeric scalar in \eqn{\[0,1\)}. Standard deviation multiplier used to add Gaussian jitter to \code{fs} and \code{fw}. Defaults to 0.
 #'
 #' @details
 #' Presence/absence data are simulated using Bernoulli trials based on empirical frequencies of occurrence among sites (for site-level presence)
@@ -23,6 +24,8 @@
 #' This simulation assumes that differences in composition or abundance are due to spatial aggregation, as captured by the pilot data.
 #' It does not incorporate environmental gradients or species associations. For more advanced modeling of species associations,
 #' copula-based approaches as suggested by Anderson et al. (2019) may be integrated in future versions of SSP.
+#'
+#' When using a jitter.base, the simulation is stochastic. For reproducibility, use \code{set.seed()} before calling \code{simdata()}.
 #'
 #' @references
 #' Anderson, M. J., & Walsh, D. C. I. (2013). PERMANOVA, ANOSIM, and the Mantel test in the face of heterogeneous dispersions: What null hypothesis are you testing? Ecological Monographs, 83(4), 557–574.
@@ -44,69 +47,84 @@
 #' ## Multiple site simulation
 #' data(sponges)
 #' par.spo <- assempar(data = sponges, type = "counts", Sest.method = "average")
-#' sim.spo <- simdata(par.spo, cases = 3, N = 10, sites = 3)
+#' set.seed(42)
+#' sim.spo <- simdata(par.spo, cases = 3, N = 10, sites = 3, jitter.base = 0.5)
 #'
 #' @importFrom stats rbinom rnbinom rnorm
 #'
 #' @export
 
-simdata <- function(Par, cases, N, sites) {
-    Par <- Par
-    N <- N
-    sites <- sites
+simdata <- function(Par, cases, N, sites, jitter.base = 0) {
+  Par <- Par
+  N <- N
+  sites <- sites
 
-# function for simulation
-    Simul <- function(Par, N, sites) {
+  # Validating jitter.base ∈ [0, 1)
+  if (jitter.base < 0 || jitter.base >= 1) {
+    stop("`jitter.base` must be a numeric in the interval [0, 1).")
+  }
 
-        fs <- Par$par$fs #Probability detection between sites
-        fw <- Par$par$fw #Probability detection within sites
-        Yh <- array(data = NA, dim = c(N, Par$Sest, sites))
+  # function for simulation
+  Simul <- function(Par, N, sites, jitter.base) {
+
+    fs <- Par$par$fs #Probability detection between sites
+    fw <- Par$par$fw #Probability detection within sites
+    Yh <- array(data = NA, dim = c(N, Par$Sest, sites))
 
     ## Simulation of presence of species using Bernoulli trials
-        for (p in seq_len(sites)) {
-            for (i in seq_len(Par$Sest)){
-                Yh[, i, p] <- rbinom(N, 1, fs[i]) # Presence in sites
-                    if (Yh[1,i,p] == 1) {
-                        Yh[, i, p] <- rbinom(N, 1, fw[i]) # Presence within sites
-                    } else {Yh[, i, p]<-rep(0, N)
-                            }
-                    }
-                }
+    for (p in seq_len(sites)) {
+      jittS <- rnorm(length(fs), mean = 0, sd = jitter.base * fs)
+      fsj <- fs + jittS
+      fsj[fsj < 0] <- 0
+      fsj[fsj > 1] <- 1
 
-# Simulation of abundances
-        for (p in seq_len(sites)) {
-            for (i in seq_len(Par$Sest)) {
-                for (j in seq_len(N)) {
-                    if (Par$type == "counts" & Yh[j, i, p] == 1) {
-                        if (Par$par$d[i] > 0 & Par$par$prob[i] < 0.05) {
-                            Yh[j, i, p] <- rnbinom(1, size = Par$par$d[i], mu = Par$par$mean[i])
-                        }
-                        if (Par$par$d[i] >= 0 & Par$par$prob[i] > 0.05 | Par$par$d[i] >=
-                            0 & is.na(Par$par$prob[i])) {
-                            Yh[j, i, p] <- rpois(1, lambda = Par$par$mean[i])
-                        }
-                    }
-                    if (Par$type == "cover" & Yh[j, i, p] == 1) {
-                        Yh[j, i, p] <- exp(rnorm(1, mean = Par$par$logmean, sd = sqrt(Par$par$logvar)))
-                    }
-                }
-            }
+      jittW <- rnorm(length(fw), mean = 0, sd = jitter.base * fw)
+      fwj <- fw + jittW
+      fwj[fwj < 0] <- 0
+      fwj[fwj > 1] <- 1
+      for (i in seq_len(Par$Sest)){
+        Yh[, i, p] <- rbinom(N, 1, fsj[i]) # Presence in sites
+        if (Yh[1,i,p] == 1) {
+          Yh[, i, p] <- rbinom(N, 1, fwj[i]) # Presence within sites
+        } else {Yh[, i, p]<-rep(0, N)
         }
+      }
+    }
+
+    # Simulation of abundances
+    for (p in seq_len(sites)) {
+      for (i in seq_len(Par$Sest)) {
+        for (j in seq_len(N)) {
+          if (Par$type == "counts" & Yh[j, i, p] == 1) {
+            if (Par$par$d[i] > 0 & Par$par$prob[i] < 0.05) {
+              Yh[j, i, p] <- rnbinom(1, size = Par$par$d[i], mu = Par$par$mean[i])
+            }
+            if (Par$par$d[i] >= 0 & Par$par$prob[i] > 0.05 | Par$par$d[i] >=
+                0 & is.na(Par$par$prob[i])) {
+              Yh[j, i, p] <- rpois(1, lambda = Par$par$mean[i])
+            }
+          }
+          if (Par$type == "cover" & Yh[j, i, p] == 1) {
+            Yh[j, i, p] <- exp(rnorm(1, mean = Par$par$logmean, sd = sqrt(Par$par$logvar)))
+          }
+        }
+      }
+    }
     #bind the sites in a data frame
-        Yh<-data.frame(apply(Yh, MARGIN = 2, rbind))
-        colnames(Yh)<- Par$par$Species
+    Yh<-data.frame(apply(Yh, MARGIN = 2, rbind))
+    colnames(Yh)<- Par$par$Species
 
     #Add columns for the id of samples and sites
-        Yh$N<-rep.int(1:N, sites)
-        Yh$sites<-gl(n = sites, k = N)
-        return(Yh)
-    }
+    Yh$N<-rep.int(1:N, sites)
+    Yh$sites<-gl(n = sites, k = N)
+    return(Yh)
+  }
 
-# generation of several simulated data sets
-    simulated.data <- vector("list", cases)
-    for (i in 1:cases) {
-        simulated.data[[i]] <- Simul(Par = Par, N = N, sites = sites)
-    }
-    return(simulated.data)
+  # generation of several simulated data sets
+  simulated.data <- vector("list", cases)
+  for (i in 1:cases) {
+    simulated.data[[i]] <- Simul(Par = Par, N = N,
+                                 sites = sites, jitter.base = jitter.base)
+  }
+  return(simulated.data)
 }
-

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,5 +1,26 @@
 ## Resubmission
 
+This is a resubmission. In this version we have: 
+
+- Updated `simdata()` to optionally increase stochasticity in simulations via the `jitter.base` parameter (default 0). This change is backward-compatible and does not alter results unless the user opts in.
+  
+### Test environments
+
+- Local: Ubuntu 22.04 (`devtools::check()`)
+- Remote: Windows (devel) via `devtools::check_win_devel()`
+
+### R CMD check results SSP 1.1.0
+
+Duration: 1m 18.5s
+
+0 errors ✔ | 0 warnings ✔ | 0 notes ✔
+
+### Reverse dependencies
+
+- Only **ecocbo** depends on **SSP**; it is maintained by the same team. We are updating both packages in tandem to ensure compatibility.
+
+## Resubmission
+
 This is a resubmission of the SSP package (version 1.0.2) to CRAN, following the request to fix cross-references in Rd files.
 
 ### Changes in this version:

--- a/man/simdata.Rd
+++ b/man/simdata.Rd
@@ -4,7 +4,7 @@
 \alias{simdata}
 \title{Simulation of Ecological Data Sets}
 \usage{
-simdata(Par, cases, N, sites)
+simdata(Par, cases, N, sites, jitter.base = 0)
 }
 \arguments{
 \item{Par}{A list of parameters estimated by \code{\link{assempar}}.}
@@ -14,6 +14,8 @@ simdata(Par, cases, N, sites)
 \item{N}{Number of samples to simulate in each site.}
 
 \item{sites}{Number of sites to simulate in each data set.}
+
+\item{jitter.base}{Numeric scalar in \eqn{\[0,1\)}. Standard deviation multiplier used to add Gaussian jitter to \code{fs} and \code{fw}. Defaults to 0.}
 }
 \value{
 A list of simulated community data sets, to be used by \code{\link{datquality}} and \code{\link{sampsd}}.
@@ -35,6 +37,8 @@ assemblage, but without incorporating environmental constraints or species co-oc
 This simulation assumes that differences in composition or abundance are due to spatial aggregation, as captured by the pilot data.
 It does not incorporate environmental gradients or species associations. For more advanced modeling of species associations,
 copula-based approaches as suggested by Anderson et al. (2019) may be integrated in future versions of SSP.
+
+When using a jitter.base, the simulation is stochastic. For reproducibility, use \code{set.seed()} before calling \code{simdata()}.
 }
 \examples{
 ## Single site simulation
@@ -45,7 +49,8 @@ sim.mic <- simdata(par.mic, cases = 3, N = 10, sites = 1)
 ## Multiple site simulation
 data(sponges)
 par.spo <- assempar(data = sponges, type = "counts", Sest.method = "average")
-sim.spo <- simdata(par.spo, cases = 3, N = 10, sites = 3)
+set.seed(42)
+sim.spo <- simdata(par.spo, cases = 3, N = 10, sites = 3, jitter.base = 0.5)
 
 }
 \references{


### PR DESCRIPTION
Se actualiza la función simdata para incluir la opción de ampliar la dispersión en simulaciones con el parámetro jitter.base fijado por el usuario. 